### PR TITLE
Specify mistralai version in requirements to avoid import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 fastui
 python-multipart
-mistralai
+mistralai==0.4.2
 python-decouple


### PR DESCRIPTION
Fixes #1 

Details: 

> Installing from `requirements.txt` in a fresh conda environment and running `uvicorn main:app --reload` results in:
> 
> ```
> Traceback (most recent call last):
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
>     self.run()
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/multiprocessing/process.py", line 108, in run
>     self._target(*self._args, **self._kwargs)
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/_subprocess.py", line 80, in subprocess_started
>     target(sockets=sockets)
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/server.py", line 65, in run
>     return asyncio.run(self.serve(sockets=sockets))
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/asyncio/runners.py", line 194, in run
>     return runner.run(main)
>            ^^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/asyncio/runners.py", line 118, in run
>     return self._loop.run_until_complete(task)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/asyncio/base_events.py", line 664, in run_until_complete
>     return future.result()
>            ^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/server.py", line 69, in serve
>     await self._serve(sockets)
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/server.py", line 76, in _serve
>     config.load()
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/config.py", line 434, in load
>     self.loaded_app = import_from_string(self.app)
>                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/importer.py", line 22, in import_from_string
>     raise exc from None
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
>     module = importlib.import_module(module_str)
>              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/Users/Jonathan/miniconda3/envs/fastui/lib/python3.12/importlib/__init__.py", line 90, in import_module
>     return _bootstrap._gcd_import(name[level:], package, level)
>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
>   File "<frozen importlib._bootstrap>", line 1354, in _find_and_load
>   File "<frozen importlib._bootstrap>", line 1325, in _find_and_load_unlocked
>   File "<frozen importlib._bootstrap>", line 929, in _load_unlocked
>   File "<frozen importlib._bootstrap_external>", line 994, in exec_module
>   File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
>   File "/Users/Jonathan/Projects/example-fastui-chatbot/main.py", line 11, in <module>
>     from mistralai.models.chat_completion import ChatMessage
> ModuleNotFoundError: No module named 'mistralai.models.chat_completion'
> ```
> 
> This is solved by changing `mistralai` to `mistralai==0.4.2` in `requirements.txt`.

